### PR TITLE
feat: add alembic_version_table_schema argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ _Note that some inputs are not required for all database types, such as SQLite._
 - `db_user`: The username for database access.
 - `db_password`: The password for database access.
 - `db_name`: The name of the database to check.
+- `alembic_version_table_schema`: The database schema containing the alembic_version table. Defaults to `public`
 - `migrations_path`: The path to your Alembic migrations folder. Defaults to `./migrations/`.
 
 ___
@@ -86,6 +87,7 @@ using a different port.
     db_user: ${{ secrets.DB_USER }}
     db_password: ${{ secrets.DB_PASSWORD }}
     db_name: ${{ secrets.DB_NAME }}
+    alembic_version_table_schema: ${{ secrets.ALEMBIC_VERSION_TABLE_SCHEMA }}
     migrations_path: ./migrations/
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: "Path to the Alembic migrations folder. Default: './migrations/'"
     required: false
     default: "./migrations/"
+  alembic_version_table_schema:
+    description: "Schema name for the alembic_version table. Default: 'public'"
+    required: false
+    default: "public"
 runs:
   using: "docker"
   image: "Dockerfile"
@@ -47,4 +51,5 @@ runs:
     - ${{ inputs.db_user }}
     - ${{ inputs.db_password }}
     - ${{ inputs.db_name }}
+    - ${{ inputs.alembic_version_table_schema }}
     - ${{ inputs.migrations_path }}

--- a/action/check_alembic_migration.py
+++ b/action/check_alembic_migration.py
@@ -175,13 +175,11 @@ class AlembicMigrationChecker:
         """Fetches and returns the current database version from the Alembic version table."""
         print("Attempting to fetch the current database version...")
         try:
-            metadata = MetaData()
+            schema = self.alembic_version_table_schema or "public"
+            metadata = MetaData(schema=schema)
             metadata.reflect(bind=self.engine)
             alembic_version_table = metadata.tables.get(
                 f"{self.alembic_version_table_schema}.alembic_version"
-                if self.alembic_version_table_schema
-                and self.alembic_version_table_schema != "public"
-                else "alembic_version"
             )
             if alembic_version_table is None:
                 raise ValueError("Alembic version table not found.")

--- a/action/check_alembic_migration.py
+++ b/action/check_alembic_migration.py
@@ -177,12 +177,15 @@ class AlembicMigrationChecker:
         try:
             metadata = MetaData()
             metadata.reflect(bind=self.engine)
-            alembic_version_table = (
-                f"{self.schema}.alembic_version"
-                if (self.schema and self.schema != "public")
+            alembic_version_table = metadata.tables.get(
+                f"{self.alembic_version_table_schema}.alembic_version"
+                if self.alembic_version_table_schema
+                and self.alembic_version_table_schema != "public"
                 else "alembic_version"
             )
-            alembic_version_table = metadata.tables[alembic_version_table]
+            if alembic_version_table is None:
+                raise ValueError("Alembic version table not found.")
+
             query = select(alembic_version_table.c.version_num).limit(1)
             with self.engine.connect() as connection:
                 result = connection.execute(query)

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -l
 
-python /check_alembic_migration.py --db_url="${INPUT_DB_URL}" --db_type="${INPUT_DB_TYPE}" --db_host="${INPUT_DB_HOST}" --db_port="${INPUT_DB_PORT}" --db_user="${INPUT_DB_USER}" --db_password="${INPUT_DB_PASSWORD}" --db_name="${INPUT_DB_NAME}" --migrations_path="${INPUT_MIGRATIONS_PATH}"
+python /check_alembic_migration.py --db_url="${INPUT_DB_URL}" --db_type="${INPUT_DB_TYPE}" --db_host="${INPUT_DB_HOST}" --db_port="${INPUT_DB_PORT}" --db_user="${INPUT_DB_USER}" --db_password="${INPUT_DB_PASSWORD}" --db_name="${INPUT_DB_NAME}" --alembic_version_table_schema="${INPUT_ALEMBIC_VERSION_TABLE_SCHEMA}" --migrations_path="${INPUT_MIGRATIONS_PATH}"


### PR DESCRIPTION
Our alembic setup has 2 separate schemas managed by alembic, both with their own respective alembic_version tables.

ex, our alembic.ini:

```
[schema_one]
script_location = alembic_common/schema_one
sqlalchemy.url = driver://user:pass@host/dbname?schema=schema_one

[schema_two]
script_location = alembic_common/schema_two
sqlalchemy.url = driver://user:pass@host/dbname?schema=schema_two
```


This change supports the new argument `alembic_version_table_schema` which allows us to specify where the alembic_version table lives.